### PR TITLE
Upgraded to Gradle 8.5 and updated dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,21 +1,31 @@
 plugins {
     id 'java'
-    id 'maven'
+    id 'maven-publish'
 }
 
 group 'com.froobworld'
 version '1.0.2'
 
-sourceCompatibility = 1.8
+sourceCompatibility = JavaVersion.VERSION_21
+targetCompatibility = JavaVersion.VERSION_21
 
 repositories {
+    mavenLocal()
     mavenCentral()
     maven {
-        url "https://hub.spigotmc.org/nexus/content/repositories/snapshots"
+        url "https://minevolt.net/repo/"
     }
 }
 
 dependencies {
-    testCompile group: 'junit', name: 'junit', version: '4.12'
-    compileOnly group: 'org.bukkit', name: 'bukkit', version: '1.14.4-R0.1-SNAPSHOT'
+    testImplementation group: 'junit', name: 'junit', version: '4.13.2'
+    compileOnly group: 'org.bukkit', name: 'bukkit', version: '1.18.2-R0.1-SNAPSHOT'
+}
+
+publishing {
+    publications {
+        mavenJava(MavenPublication) {
+            from components.java
+        }
+    }
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.2.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Pull request for #1. Builds for Java 21 (minimum required for MC 1.20.5+) tested using Adoptium.

Slight change from `./gradlew clean install` to `./gradlew clean publishToMavenLocal` due to Gradle 8.5 upgrade. Appears to build fine on my side - just trying to bring ViewDistanceTweaks up to 1.20.6 now that it's stable on PurpurMC. Feel free to edit.